### PR TITLE
Use dotenv for token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and replace with your Discord bot token
+DISCORD_TOKEN=your_token_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -4,12 +4,16 @@
 
 ## 사용 방법
 
-1. `discord.py` 라이브러리를 설치합니다:
+1. 필요한 라이브러리를 설치합니다:
    ```bash
-   pip install discord.py
+   pip install -r requirements.txt
    ```
 
-2. `DISCORD_TOKEN` 환경 변수를 여러분의 봇 토큰으로 설정합니다.
+2. 루트 디렉터리에 `.env` 파일을 만들고 다음과 같이 봇 토큰을 설정합니다:
+   ```env
+   DISCORD_TOKEN=여러분의봇토큰
+   ```
+   혹은 `DISCORD_TOKEN` 환경 변수를 직접 설정해도 됩니다.
 
 3. `bot.py`를 실행하여 봇을 시작합니다:
    ```bash

--- a/bot.py
+++ b/bot.py
@@ -2,7 +2,9 @@ import os
 import discord
 from discord import app_commands
 from discord.ext import commands
+from dotenv import load_dotenv
 
+load_dotenv()
 TOKEN = os.getenv('DISCORD_TOKEN')
 
 description = "간단한 디스코드 봇"
@@ -28,5 +30,5 @@ async def slash_command(interaction: discord.Interaction):
 
 if __name__ == "__main__":
     if not TOKEN:
-        raise RuntimeError("DISCORD_TOKEN 환경변수가 설정되지 않았습니다.")
+        raise RuntimeError("DISCORD_TOKEN 값이 설정되지 않았습니다. 환경 변수로 설정하거나 .env 파일을 사용하세요.")
     bot.run(TOKEN)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 discord.py==2.3.2
+python-dotenv>=1.0.0


### PR DESCRIPTION
## Summary
- support `.env` file by loading it in `bot.py`
- update README to document `.env` usage and requirements installation
- include example `.env` file
- add `.gitignore` to exclude `.env`
- require `python-dotenv` in requirements

## Testing
- `python -m py_compile bot.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68517fe1d650832b95e564f626fe41bb