### PR TITLE
Fix nick missing display

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -83,8 +83,9 @@ async def honey_command(interaction: discord.Interaction):
             avatar_url = None
 
     embed = discord.Embed(color=discord.Color.gold())
+    display_name = info.get("nick") or info.get("name") or "알수없음"
     embed.set_author(
-        name=f"{info.get('nick','알수없음')}#{info['discriminator']}",
+        name=f"{display_name}#{info['discriminator']}",
         icon_url=avatar_url,
     )
     embed.add_field(name="내 허니", value=str(info.get("honey", 0)), inline=True)


### PR DESCRIPTION
## Summary
- fix nickname display when missing and fallback to username

## Testing
- `python -m py_compile bot.py db.py`


------
https://chatgpt.com/codex/tasks/task_e_685199d24798832b980d514fe86b1bf3