### PR TITLE
Set timezone to KST

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -13,6 +13,12 @@ from dotenv import load_dotenv
 import db
 
 load_dotenv()
+# Set timezone to Korea Standard Time
+os.environ["TZ"] = "Asia/Seoul"
+try:
+    time.tzset()
+except AttributeError:
+    pass
 TOKEN = os.getenv('DISCORD_TOKEN')
 
 description = "간단한 디스코드 봇"


### PR DESCRIPTION
## Summary
- ensure `bot.py` uses Korea Standard Time by setting `TZ` to `Asia/Seoul`

## Testing
- `python -m py_compile bot.py db.py honey_counter.py`

------
https://chatgpt.com/codex/tasks/task_e_68597c94cffc832b979e1fb2a70f32b5