### PR TITLE
Apply permanent gacha effects

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -210,9 +210,8 @@ def apply_flower_effect(user_id: str, item: dict) -> str:
         db.add_honey(user_id, level["reward"])
         db.add_adventure_log(user_id, "성공", level["reward"], level["reward"])
         return f"{item['name']}의 힘으로 {level['name']} 모험을 성공해 {level['reward']} 허니를 얻었습니다!"
-    expires = now + item.get("duration", 0)
-    db.add_effect(user_id, effect, expires, {"value": item.get("value")})
-    return f"{item['name']} 효과가 {item.get('duration',0)//60}분 동안 적용됩니다!"
+    db.add_effect(user_id, effect, 0, {"value": item.get("value")})
+    return f"{item['name']} 효과가 영구적으로 적용됩니다!"
 
 
 async def run_adventure(interaction: discord.Interaction, level: dict):
@@ -664,7 +663,10 @@ async def flower_gacha(interaction: discord.Interaction):
             chosen = item
             break
     result_text = apply_flower_effect(user_id, chosen)
-    await interaction.response.send_message(result_text, ephemeral=False)
+    embed = discord.Embed(title=f"{chosen['name']} 획득!", color=discord.Color.gold())
+    embed.add_field(name="등급", value=chosen.get("rarity", "?"), inline=False)
+    embed.add_field(name="효과", value=result_text, inline=False)
+    await interaction.response.send_message(embed=embed, ephemeral=False)
 
 
 @app_commands.command(name="모험확률", description="관리자만 사용가능합니다 모험 확률을 설정합니다")

--- a/db.py
+++ b/db.py
@@ -402,7 +402,10 @@ def get_active_effects(user_id: str) -> list[dict]:
     now = int(time.time())
     conn = sqlite3.connect(DB_FILE)
     cur = conn.cursor()
-    cur.execute("DELETE FROM user_effects WHERE expires_at <= ?", (now,))
+    cur.execute(
+        "DELETE FROM user_effects WHERE expires_at > 0 AND expires_at <= ?",
+        (now,),
+    )
     conn.commit()
     cur.execute(
         "SELECT effect, expires_at, data FROM user_effects WHERE user_id=?",


### PR DESCRIPTION
## Summary
- keep flower gacha effects forever
- show pulled flower rarity and effect in an embed

## Testing
- `python -m py_compile bot.py db.py honey_counter.py`


------
https://chatgpt.com/codex/tasks/task_e_685c0dfab0ec832b9847e5a35ed9f472