### PR TITLE
Implement API server and connect dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 # Copy this file to .env and replace with your Discord bot token
 DISCORD_TOKEN=your_token_here
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -53,4 +53,8 @@ docker compose build
 docker compose up
 ```
 
+`api` 서비스가 함께 실행되어 웹 대시보드에서 데이터를 조회할 수 있습니다. 기본적으로
+`http://localhost:8000` 에서 API가 동작하므로 프론트엔드의 `NEXT_PUBLIC_API_BASE_URL`
+환경 변수를 동일하게 맞춰 주어야 합니다.
+
 컨테이너는 `users.db` 파일을 호스트와 공유하므로 데이터를 유지한 채 재시작할 수 있습니다.

--- a/api.py
+++ b/api.py
@@ -1,0 +1,34 @@
+import db
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+db.init_db()
+
+@app.get("/users")
+def list_users():
+    return db.get_all_users()
+
+@app.get("/users/{user_id}")
+def user_detail(user_id: str):
+    user = db.get_user(user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    user["pointHistory"] = db.get_honey_history(user_id, limit=20)
+    user["activityLogs"] = db.get_recent_adventure_logs(user_id, limit=20)
+    return user
+
+@app.post("/users/{user_id}/points")
+def adjust_points(user_id: str, payload: dict):
+    amount = int(payload.get("amount", 0))
+    if not amount:
+        raise HTTPException(status_code=400, detail="amount required")
+    db.add_honey(user_id, amount)
+    return {"status": "ok"}

--- a/db.py
+++ b/db.py
@@ -16,7 +16,8 @@ def init_db():
             discriminator TEXT NOT NULL,
             avatar_url TEXT,
             nick TEXT,
-            honey INTEGER NOT NULL DEFAULT 0
+            honey INTEGER NOT NULL DEFAULT 0,
+            joined_at INTEGER NOT NULL DEFAULT (strftime('%s','now'))
         )
         """
     )
@@ -58,6 +59,8 @@ def init_db():
         cur.execute("ALTER TABLE users ADD COLUMN nick TEXT")
     if "honey" not in columns:
         cur.execute("ALTER TABLE users ADD COLUMN honey INTEGER NOT NULL DEFAULT 0")
+    if "joined_at" not in columns:
+        cur.execute("ALTER TABLE users ADD COLUMN joined_at INTEGER NOT NULL DEFAULT (strftime('%s','now'))")
     cur.execute(
         """
         CREATE TABLE IF NOT EXISTS adventure_probabilities (
@@ -105,17 +108,20 @@ def add_or_update_user(
 ):
     conn = sqlite3.connect(DB_FILE)
     cur = conn.cursor()
+    cur.execute("SELECT joined_at FROM users WHERE user_id=?", (user_id,))
+    row = cur.fetchone()
+    joined_at = int(time.time()) if row is None else row[0]
     cur.execute(
         """
-        INSERT INTO users(user_id, name, discriminator, avatar_url, nick, honey)
-        VALUES (?, ?, ?, ?, ?, ?)
+        INSERT INTO users(user_id, name, discriminator, avatar_url, nick, honey, joined_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(user_id) DO UPDATE SET
             name=excluded.name,
             discriminator=excluded.discriminator,
             avatar_url=excluded.avatar_url,
             nick=excluded.nick
         """,
-        (user_id, name, discriminator, avatar_url, nick, honey),
+        (user_id, name, discriminator, avatar_url, nick, honey, joined_at),
     )
     conn.commit()
     conn.close()
@@ -125,15 +131,44 @@ def get_user(user_id: str):
     conn = sqlite3.connect(DB_FILE)
     cur = conn.cursor()
     cur.execute(
-        "SELECT user_id, name, discriminator, avatar_url, nick, honey FROM users WHERE user_id=?",
+        "SELECT user_id, name, discriminator, avatar_url, nick, honey, joined_at FROM users WHERE user_id=?",
         (user_id,),
     )
     row = cur.fetchone()
     conn.close()
     if row:
-        keys = ["user_id", "name", "discriminator", "avatar_url", "nick", "honey"]
+        keys = ["user_id", "name", "discriminator", "avatar_url", "nick", "honey", "joined_at"]
         return dict(zip(keys, row))
     return None
+
+
+def get_all_users():
+    """Return a list of all users."""
+    conn = sqlite3.connect(DB_FILE)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT user_id, name, discriminator, avatar_url, nick, honey, joined_at FROM users"
+    )
+    rows = cur.fetchall()
+    conn.close()
+    keys = ["user_id", "name", "discriminator", "avatar_url", "nick", "honey", "joined_at"]
+    return [dict(zip(keys, row)) for row in rows]
+
+
+def get_honey_history(user_id: str, limit: int = 20):
+    """Return recent honey history records for a user."""
+    conn = sqlite3.connect(DB_FILE)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT timestamp, amount FROM honey_history WHERE user_id=? ORDER BY id DESC LIMIT ?",
+        (user_id, limit),
+    )
+    rows = cur.fetchall()
+    conn.close()
+    return [
+        {"timestamp": row[0], "change": row[1]}
+        for row in rows
+    ]
 
 
 def add_honey(user_id: str, amount: int):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,9 @@ services:
     volumes:
       - ./users.db:/app/users.db
     restart: unless-stopped
+  api:
+    build: .
+    command: ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8000"]
+    volumes:
+      - ./users.db:/app/users.db
+    restart: unless-stopped

--- a/flang-bot-web/app/(dashboard)/users/page.tsx
+++ b/flang-bot-web/app/(dashboard)/users/page.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image"
 import { MoreHorizontal } from "lucide-react"
 import Link from "next/link"
+import { useEffect, useState } from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -14,51 +15,28 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 
-// 샘플 사용자 데이터입니다. 실제로는 API를 통해 받아오게 됩니다.
-const users = [
-  {
-    id: "USR001",
-    name: "모험적인유저",
-    avatar: "/placeholder.svg?height=32&width=32",
-    joinedDate: "2025-01-15",
-    points: 1250,
-    status: "active",
-  },
-  {
-    id: "USR002",
-    name: "관대한기부자",
-    avatar: "/placeholder.svg?height=32&width=32",
-    joinedDate: "2025-02-20",
-    points: 500,
-    status: "active",
-  },
-  {
-    id: "USR003",
-    name: "새로운참가자",
-    avatar: "/placeholder.svg?height=32&width=32",
-    joinedDate: "2025-06-28",
-    points: 100,
-    status: "active",
-  },
-  {
-    id: "USR004",
-    name: "관리자마스터",
-    avatar: "/placeholder.svg?height=32&width=32",
-    joinedDate: "2024-12-10",
-    points: 99999,
-    status: "active",
-  },
-  {
-    id: "USR005",
-    name: "휴면계정",
-    avatar: "/placeholder.svg?height=32&width=32",
-    joinedDate: "2025-03-05",
-    points: 50,
-    status: "inactive",
-  },
-]
-
 export default function UsersPage() {
+  const [users, setUsers] = useState<any[]>([])
+
+  useEffect(() => {
+    fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/users`)
+      .then((res) => res.json())
+      .then((data) =>
+        setUsers(
+          data.map((u: any) => ({
+            id: u.user_id,
+            name: u.name,
+            avatar: u.avatar_url,
+            joinedDate: new Date(u.joined_at * 1000)
+              .toISOString()
+              .split("T")[0],
+            points: u.honey,
+            status: "active",
+          }))
+        )
+      )
+      .catch((err) => console.error(err))
+  }, [])
   return (
     <div className="flex flex-col gap-6">
       <div className="flex items-center">

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 discord.py==2.3.2
 python-dotenv>=1.0.0
+fastapi
+uvicorn[standard]


### PR DESCRIPTION
## Summary
- add a FastAPI backend (`api.py`)
- extend DB schema with `joined_at` and expose helper functions
- update docker-compose to run the API service
- connect dashboard pages to the new API
- document API usage and env config

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile api.py db.py`

------
https://chatgpt.com/codex/tasks/task_e_685ff1f2d8ac832b91f3ab0312fdfdc4