### PR TITLE
Expose API port in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
     command: ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8000"]
     volumes:
       - ./users.db:/app/users.db
+    ports:
+      - "8000:8000"
     restart: unless-stopped
   web:
     build:


### PR DESCRIPTION
## Summary
- expose port 8000 for API service

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860177f8d50832b916f54b388ee3365