### PR TITLE
Add statistics API and dashboard

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,4 +1,6 @@
 import db
+import time
+import datetime
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -32,3 +34,15 @@ def adjust_points(user_id: str, payload: dict):
         raise HTTPException(status_code=400, detail="amount required")
     db.add_honey(user_id, amount)
     return {"status": "ok"}
+
+
+@app.get("/stats/overview")
+def stats_overview():
+    today = datetime.date.today()
+    start_of_day = int(time.mktime(today.timetuple()))
+    return {
+        "totalUsers": db.get_total_user_count(),
+        "totalHoney": db.get_total_honey(),
+        "joinedToday": db.get_joined_count_since(start_of_day),
+        "activeToday": db.get_active_user_count_since(start_of_day),
+    }

--- a/db.py
+++ b/db.py
@@ -468,3 +468,41 @@ def remove_effect(user_id: str, effect: str):
     )
     conn.commit()
     conn.close()
+
+def get_total_user_count() -> int:
+    conn = sqlite3.connect(DB_FILE)
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM users")
+    row = cur.fetchone()
+    conn.close()
+    return row[0] if row else 0
+
+
+def get_total_honey() -> int:
+    conn = sqlite3.connect(DB_FILE)
+    cur = conn.cursor()
+    cur.execute("SELECT SUM(honey) FROM users")
+    row = cur.fetchone()
+    conn.close()
+    return row[0] if row and row[0] is not None else 0
+
+
+def get_joined_count_since(ts: int) -> int:
+    conn = sqlite3.connect(DB_FILE)
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM users WHERE joined_at >= ?", (ts,))
+    row = cur.fetchone()
+    conn.close()
+    return row[0] if row else 0
+
+
+def get_active_user_count_since(ts: int) -> int:
+    conn = sqlite3.connect(DB_FILE)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT COUNT(DISTINCT user_id) FROM honey_history WHERE timestamp >= ?",
+        (ts,),
+    )
+    row = cur.fetchone()
+    conn.close()
+    return row[0] if row else 0

--- a/flang-bot-web/app/(dashboard)/page.tsx
+++ b/flang-bot-web/app/(dashboard)/page.tsx
@@ -1,10 +1,25 @@
 "use client"
 
+import { useEffect, useState } from "react"
 import { UserGrowthChart } from "@/components/user-growth-chart"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Users, Database, UserPlus, Activity } from "lucide-react"
 
 export default function DashboardPage() {
+  const [stats, setStats] = useState({
+    totalUsers: 0,
+    totalHoney: 0,
+    joinedToday: 0,
+    activeToday: 0,
+  })
+
+  useEffect(() => {
+    fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/stats/overview`)
+      .then((res) => res.json())
+      .then((data) => setStats(data))
+      .catch((err) => console.error(err))
+  }, [])
+
   return (
     <>
       <div className="flex items-center">
@@ -17,7 +32,7 @@ export default function DashboardPage() {
             <Users className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">5</div>
+            <div className="text-2xl font-bold">{stats.totalUsers.toLocaleString()}</div>
             <p className="text-xs text-muted-foreground">서버에 가입한 전체 유저 수</p>
           </CardContent>
         </Card>
@@ -27,7 +42,7 @@ export default function DashboardPage() {
             <Database className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">101,899</div>
+            <div className="text-2xl font-bold">{stats.totalHoney.toLocaleString()}</div>
             <p className="text-xs text-muted-foreground">모든 유저가 보유한 꿀의 총합</p>
           </CardContent>
         </Card>
@@ -37,7 +52,7 @@ export default function DashboardPage() {
             <UserPlus className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">+3</div>
+            <div className="text-2xl font-bold">+{stats.joinedToday.toLocaleString()}</div>
             <p className="text-xs text-muted-foreground">오늘 새로 가입한 유저 수</p>
           </CardContent>
         </Card>
@@ -47,7 +62,7 @@ export default function DashboardPage() {
             <Activity className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">4</div>
+            <div className="text-2xl font-bold">{stats.activeToday.toLocaleString()}</div>
             <p className="text-xs text-muted-foreground">오늘 채팅을 1회 이상 사용한 유저</p>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- expose `/stats/overview` endpoint with user and honey counts
- compute daily and total stats in `db.py`
- fetch these stats on the dashboard home page

## Testing
- `python -m py_compile bot.py db.py api.py honey_counter.py`
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686023de4aac832b9aeadebcf2523d82