### PR TITLE
Track guild membership for dashboard

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -369,6 +369,19 @@ async def on_voice_state_update(member: discord.Member, before: discord.VoiceSta
 
 
 @bot.event
+async def on_member_join(member: discord.Member):
+    await ensure_user_record(member, member.guild)
+    joined_ts = int(member.joined_at.timestamp()) if member.joined_at else int(time.time())
+    db.update_joined_at(str(member.id), joined_ts)
+    db.set_member_status(str(member.id), True)
+
+
+@bot.event
+async def on_member_remove(member: discord.Member):
+    db.set_member_status(str(member.id), False)
+
+
+@bot.event
 async def on_ready():
     print(f'Logged in as {bot.user} (ID: {bot.user.id})')
     try:


### PR DESCRIPTION
## Summary
- add `is_member` column to store guild membership status
- migrate existing rows to default `is_member=1`
- add helpers `set_member_status` and `update_joined_at`
- track join and leave events in the bot
- count only active guild members in statistics

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860268a7294832b80b1c1fb20f2638d