### PR TITLE
Add user registration tracking

### DIFF
--- a/api.py
+++ b/api.py
@@ -42,7 +42,9 @@ def stats_overview():
     start_of_day = int(time.mktime(today.timetuple()))
     return {
         "totalUsers": db.get_total_user_count(),
+        "registeredUsers": db.get_total_registered_user_count(),
         "totalHoney": db.get_total_honey(),
         "joinedToday": db.get_joined_count_since(start_of_day),
+        "registeredToday": db.get_registered_count_since(start_of_day),
         "activeToday": db.get_active_user_count_since(start_of_day),
     }

--- a/bot.py
+++ b/bot.py
@@ -321,6 +321,7 @@ async def ensure_user_record(user: discord.abc.User, guild: discord.Guild | None
         avatar_url,
         nick,
         0,
+        False,
     )
 
 
@@ -443,6 +444,7 @@ async def join_command(interaction: discord.Interaction):
         avatar_url,
         nick,
         honey,
+        True,
     )
     await interaction.response.send_message(
         f"{user.name}님의 정보가 저장되었습니다.", ephemeral=True

--- a/flang-bot-web/app/(dashboard)/page.tsx
+++ b/flang-bot-web/app/(dashboard)/page.tsx
@@ -8,8 +8,10 @@ import { Users, Database, UserPlus, Activity } from "lucide-react"
 export default function DashboardPage() {
   const [stats, setStats] = useState({
     totalUsers: 0,
+    registeredUsers: 0,
     totalHoney: 0,
     joinedToday: 0,
+    registeredToday: 0,
     activeToday: 0,
   })
 
@@ -38,6 +40,16 @@ export default function DashboardPage() {
         </Card>
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">등록된 유저</CardTitle>
+            <Users className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{stats.registeredUsers.toLocaleString()}</div>
+            <p className="text-xs text-muted-foreground">/가입 명령을 사용한 유저 수</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">총 꿀 유통량</CardTitle>
             <Database className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
@@ -54,6 +66,16 @@ export default function DashboardPage() {
           <CardContent>
             <div className="text-2xl font-bold">+{stats.joinedToday.toLocaleString()}</div>
             <p className="text-xs text-muted-foreground">오늘 새로 가입한 유저 수</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">오늘 등록</CardTitle>
+            <UserPlus className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">+{stats.registeredToday.toLocaleString()}</div>
+            <p className="text-xs text-muted-foreground">오늘 /가입을 완료한 유저 수</p>
           </CardContent>
         </Card>
         <Card>

--- a/flang-bot-web/app/(dashboard)/users/[userId]/page.tsx
+++ b/flang-bot-web/app/(dashboard)/users/[userId]/page.tsx
@@ -34,8 +34,14 @@ export default function UserDetailPage({ params }: { params: { userId: string } 
           joinedDate: new Date(data.joined_at * 1000)
             .toISOString()
             .split("T")[0],
+          registeredDate:
+            data.registered_at > 0
+              ? new Date(data.registered_at * 1000)
+                  .toISOString()
+                  .split("T")[0]
+              : null,
           points: data.honey,
-          status: "active",
+          status: data.registered_at > 0 ? "registered" : "unregistered",
           activityLogs: data.activityLogs.map((l: any, idx: number) => ({
             id: String(idx),
             timestamp: new Date(l.timestamp * 1000)
@@ -119,8 +125,8 @@ export default function UserDetailPage({ params }: { params: { userId: string } 
         <h1 className="flex-1 shrink-0 whitespace-nowrap text-xl font-semibold tracking-tight sm:grow-0">
           {user.name}
         </h1>
-        <Badge variant={user.status === "active" ? "secondary" : "outline"} className="ml-auto sm:ml-0">
-          {user.status === "active" ? "활동중" : "비활성"}
+        <Badge variant={user.status === "registered" ? "secondary" : "outline"} className="ml-auto sm:ml-0">
+          {user.status === "registered" ? "등록됨" : "미등록"}
         </Badge>
       </div>
       <div className="grid gap-6 md:grid-cols-[1fr_2fr] lg:grid-cols-[1fr_3fr]">
@@ -145,6 +151,12 @@ export default function UserDetailPage({ params }: { params: { userId: string } 
               <div className="w-full grid grid-cols-[auto_1fr] gap-x-4 gap-y-2">
                 <span className="text-muted-foreground">가입일</span>
                 <span className="text-right font-medium">{user.joinedDate}</span>
+                {user.registeredDate && (
+                  <>
+                    <span className="text-muted-foreground">등록일</span>
+                    <span className="text-right font-medium">{user.registeredDate}</span>
+                  </>
+                )}
                 <span className="text-muted-foreground">보유 꿀</span>
                 <span className="text-right font-medium">{user.points.toLocaleString()} 꿀</span>
               </div>

--- a/flang-bot-web/app/(dashboard)/users/page.tsx
+++ b/flang-bot-web/app/(dashboard)/users/page.tsx
@@ -33,7 +33,7 @@ export default function UsersPage() {
               .toISOString()
               .split("T")[0],
             points: u.honey,
-            status: "active",
+            status: u.registered_at > 0 ? "registered" : "unregistered",
           }))
         )
       )
@@ -80,8 +80,8 @@ export default function UsersPage() {
                   <TableCell className="hidden md:table-cell">{user.joinedDate}</TableCell>
                   <TableCell className="hidden md:table-cell">{user.points.toLocaleString()} 꿀</TableCell>
                   <TableCell>
-                    <Badge variant={user.status === "active" ? "secondary" : "outline"}>
-                      {user.status === "active" ? "활동중" : "비활성"}
+                    <Badge variant={user.status === "registered" ? "secondary" : "outline"}>
+                      {user.status === "registered" ? "등록됨" : "미등록"}
                     </Badge>
                   </TableCell>
                   <TableCell>


### PR DESCRIPTION
## Summary
- track when users register using `/가입`
- expose registration info via API
- display registration stats and indicators in dashboard

## Testing
- `python3 -m py_compile api.py bot.py db.py honey_counter.py`
- `pytest -q`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686030ede5cc832bb155136d9b1ab39b