### PR TITLE
Enable database-backed logs

### DIFF
--- a/api.py
+++ b/api.py
@@ -23,70 +23,6 @@ user_growth_data = [
     {"month": "6월", "joined": 214, "left": 140},
 ]
 
-bot_usage_logs = [
-    {
-        "id": "LOG001",
-        "timestamp": "2025-06-29 10:30:15",
-        "user": {"name": "모험적인유저", "avatar": "/placeholder.svg?height=32&width=32"},
-        "command": "/모험",
-        "details": "성공 - 50 꿀 획득",
-    },
-    {
-        "id": "LOG002",
-        "timestamp": "2025-06-29 10:28:45",
-        "user": {"name": "관대한기부자", "avatar": "/placeholder.svg?height=32&width=32"},
-        "command": "/허니선물",
-        "details": "모험적인유저에게 100 꿀 선물",
-    },
-    {
-        "id": "LOG003",
-        "timestamp": "2025-06-28 10:25:02",
-        "user": {"name": "새로운참가자", "avatar": "/placeholder.svg?height=32&width=32"},
-        "command": "/가입",
-        "details": "신규 가입 완료",
-    },
-    {
-        "id": "LOG004",
-        "timestamp": "2025-06-28 10:20:11",
-        "user": {"name": "모험적인유저", "avatar": "/placeholder.svg?height=32&width=32"},
-        "command": "/모험",
-        "details": "실패 - 20 꿀 잃음",
-    },
-    {
-        "id": "LOG005",
-        "timestamp": "2025-06-27 10:15:55",
-        "user": {"name": "관리자마스터", "avatar": "/placeholder.svg?height=32&width=32"},
-        "command": "/지급",
-        "details": "관대한기부자에게 1000 꿀 지급",
-    },
-]
-
-admin_logs_data = [
-    {
-        "id": "ALOG001",
-        "timestamp": "2025-06-29 14:10:25",
-        "admin": {"name": "관리자마스터", "avatar": "/placeholder.svg?height=32&width=32"},
-        "targetUser": {"name": "모험적인유저"},
-        "action": "포인트 지급",
-        "details": "1,000 꿀 (사유: 주간 이벤트 우승 보상)",
-    },
-    {
-        "id": "ALOG002",
-        "timestamp": "2025-06-29 11:05:11",
-        "admin": {"name": "부관리자", "avatar": "/placeholder.svg?height=32&width=32"},
-        "targetUser": {"name": "관대한기부자"},
-        "action": "포인트 차감",
-        "details": "500 꿀 (사유: 시스템 오류로 인한 과지급 회수)",
-    },
-    {
-        "id": "ALOG003",
-        "timestamp": "2025-06-28 18:30:00",
-        "admin": {"name": "관리자마스터", "avatar": "/placeholder.svg?height=32&width=32"},
-        "targetUser": {"name": "새로운참가자"},
-        "action": "포인트 지급",
-        "details": "200 꿀 (사유: 버그 제보 보상)",
-    },
-]
 
 @app.get("/users")
 def list_users():
@@ -131,9 +67,15 @@ def user_growth():
 
 @app.get("/logs/bot")
 def bot_logs():
-    return bot_usage_logs
+    logs = db.get_recent_bot_logs()
+    for log in logs:
+        log["timestamp"] = datetime.datetime.fromtimestamp(log["timestamp"]).strftime("%Y-%m-%d %H:%M:%S")
+    return logs
 
 
 @app.get("/logs/admin")
 def admin_logs():
-    return admin_logs_data
+    logs = db.get_recent_admin_logs()
+    for log in logs:
+        log["timestamp"] = datetime.datetime.fromtimestamp(log["timestamp"]).strftime("%Y-%m-%d %H:%M:%S")
+    return logs

--- a/bot.py
+++ b/bot.py
@@ -34,6 +34,13 @@ honey_group = app_commands.Group(name="허니", description="허니 관련 명�
 # 랭킹 명령 그룹
 ranking_group = app_commands.Group(name="랭킹", description="랭킹 관련 명령")
 
+
+def log_command(interaction: discord.Interaction, command: str, details: str = ""):
+    try:
+        db.add_bot_log(str(interaction.user.id), command, details)
+    except Exception as e:
+        print(f"Failed to log command: {e}")
+
 # Adventure level settings
 ADVENTURE_LEVELS = [
     {
@@ -295,6 +302,8 @@ async def run_adventure(interaction: discord.Interaction, level: dict):
     if "cooldown_half" in effects:
         cooldown_seconds = cooldown_seconds // 2
     db.set_adventure_cooldown(user_id, int(time.time()) + cooldown_seconds)
+    result = "성공" if success else "실패"
+    log_command(interaction, "/모험", f"{level['name']} {result} {reward if success else 0}허니")
 
 
 async def ensure_user_record(user: discord.abc.User, guild: discord.Guild | None = None):
@@ -417,6 +426,7 @@ async def on_ready():
 @app_commands.command(name="인사", description="인사 메시지")
 async def greet_command(interaction: discord.Interaction):
     await interaction.response.send_message("안녕하세요!", ephemeral=True)
+    log_command(interaction, "/인사")
 
 
 @app_commands.command(name="가입", description="봇 서비스를 위한 가입")
@@ -449,6 +459,7 @@ async def join_command(interaction: discord.Interaction):
     await interaction.response.send_message(
         f"{user.name}님의 정보가 저장되었습니다.", ephemeral=True
     )
+    log_command(interaction, "/가입")
 
 
 @app_commands.command(name="꿀단지", description="저장된 유저 정보 보기")
@@ -513,6 +524,7 @@ async def honey_command(interaction: discord.Interaction):
         )
 
     await interaction.response.send_message(embed=embed, ephemeral=False)
+    log_command(interaction, "/꿀단지")
 
 
 @honey_group.command(name="선물", description="다른 사용자에게 허니를 선물합니다")
@@ -559,6 +571,7 @@ async def gift_honey(
         f"{user.mention}에게 {amount} 허니를 선물했습니다!",
         ephemeral=True,
     )
+    log_command(interaction, "/허니선물", f"{user.display_name}에게 {amount} 선물")
 
     # Notify the receiver via DM with an embed
     sender_display = getattr(interaction.user, "display_name", interaction.user.name)
@@ -617,6 +630,7 @@ async def adventure_logs_command(interaction: discord.Interaction):
             inline=False,
         )
     await interaction.response.send_message(embed=embed, ephemeral=True)
+    log_command(interaction, "/모험기록")
 
 
 @ranking_group.command(name="주간", description="일주일 동안 획득한 허니 랭킹")
@@ -639,6 +653,7 @@ async def weekly_ranking(interaction: discord.Interaction):
         name = row["nick"] or row["name"]
         embed.add_field(name=f"{idx}위 - {name}", value=f"+{row['earned']}", inline=False)
     await interaction.response.send_message(embed=embed, ephemeral=False)
+    log_command(interaction, "/랭킹 주간")
 
 
 @ranking_group.command(name="월간", description="한 달 동안 획득한 허니 랭킹")
@@ -663,6 +678,7 @@ async def monthly_ranking(interaction: discord.Interaction):
         name = row["nick"] or row["name"]
         embed.add_field(name=f"{idx}위 - {name}", value=f"+{row['earned']}", inline=False)
     await interaction.response.send_message(embed=embed, ephemeral=False)
+    log_command(interaction, "/랭킹 월간")
 
 
 @ranking_group.command(name="누적", description="보유 허니 기준 랭킹")
@@ -680,6 +696,7 @@ async def total_ranking(interaction: discord.Interaction):
         name = row["nick"] or row["name"]
         embed.add_field(name=f"{idx}위 - {name}", value=str(row['honey']), inline=False)
     await interaction.response.send_message(embed=embed, ephemeral=False)
+    log_command(interaction, "/랭킹 누적")
 
 
 @app_commands.command(name="꽃뽑기", description="꽃 아이템을 뽑습니다")
@@ -707,6 +724,7 @@ async def flower_gacha(interaction: discord.Interaction):
     embed.add_field(name="등급", value=chosen.get("rarity", "?"), inline=False)
     embed.add_field(name="효과", value=result_text, inline=False)
     await interaction.response.send_message(embed=embed, ephemeral=False)
+    log_command(interaction, "/꽃뽑기", chosen.get("name", ""))
 
 
 


### PR DESCRIPTION
## Summary
- add tables for bot and admin logs
- implement helpers in `db.py` to add and read log entries
- log major commands from the bot
- serve logs from database in API

## Testing
- `python -m py_compile bot.py api.py db.py honey_counter.py`

------
https://chatgpt.com/codex/tasks/task_e_686037900bf8832b962668d4c22019f7