### PR TITLE
Implement simple login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 # Copy this file to .env and replace with your Discord bot token
 DISCORD_TOKEN=your_token_here
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=changeme

--- a/api.py
+++ b/api.py
@@ -1,6 +1,7 @@
 import db
 import time
 import datetime
+import os
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -11,6 +12,10 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Simple admin credentials for login
+ADMIN_USERNAME = os.getenv("ADMIN_USERNAME", "admin")
+ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "password")
 
 db.init_db()
 
@@ -79,3 +84,12 @@ def admin_logs():
     for log in logs:
         log["timestamp"] = datetime.datetime.fromtimestamp(log["timestamp"]).strftime("%Y-%m-%d %H:%M:%S")
     return logs
+
+
+@app.post("/login")
+def login(payload: dict):
+    username = payload.get("username")
+    password = payload.get("password")
+    if username == ADMIN_USERNAME and password == ADMIN_PASSWORD:
+        return {"status": "ok"}
+    raise HTTPException(status_code=401, detail="Invalid credentials")

--- a/flang-bot-web/app/(dashboard)/layout.tsx
+++ b/flang-bot-web/app/(dashboard)/layout.tsx
@@ -6,7 +6,7 @@ import Link from "next/link"
 import Image from "next/image"
 import { usePathname, useRouter } from "next/navigation"
 import { Home, Bot, PanelLeft, Search, Swords, Coins, History, Users, ShieldCheck } from "lucide-react"
-import { Suspense } from "react"
+import { Suspense, useEffect } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -39,9 +39,23 @@ export default function DashboardLayout({
     { href: "/admin-logs", label: "관리자 로그", icon: ShieldCheck },
   ]
 
+  useEffect(() => {
+    const loggedIn = localStorage.getItem("loggedIn")
+    if (!loggedIn && pathname !== "/login") {
+      router.push("/login")
+    } else if (loggedIn && pathname === "/login") {
+      router.push("/")
+    }
+  }, [pathname, router])
+
   const handleLogout = () => {
     // 실제 애플리케이션에서는 로그아웃 API 호출 및 세션 정리 로직이 필요합니다.
+    localStorage.removeItem("loggedIn")
     router.push("/login")
+  }
+
+  if (pathname === "/login") {
+    return <>{children}</>
   }
 
   return (

--- a/flang-bot-web/app/(dashboard)/login/page.tsx
+++ b/flang-bot-web/app/(dashboard)/login/page.tsx
@@ -13,12 +13,23 @@ import { Label } from "@/components/ui/label"
 export default function LoginPage() {
   const router = useRouter()
 
-  const handleLogin = (event: React.FormEvent) => {
+  const handleLogin = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
-    // 실제 애플리케이션에서는 여기서 인증 로직을 처리합니다.
-    // 예: const response = await fetch('/api/login', { ... });
-    // 로그인이 성공했다고 가정하고 대시보드로 리디렉션합니다.
-    router.push("/")
+    const form = event.currentTarget
+    const username = (form.elements.namedItem("username") as HTMLInputElement).value
+    const password = (form.elements.namedItem("password") as HTMLInputElement).value
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password }),
+      })
+      if (!res.ok) throw new Error("login failed")
+      localStorage.setItem("loggedIn", "true")
+      router.push("/")
+    } catch (err) {
+      alert("로그인 실패")
+    }
   }
 
   return (
@@ -35,11 +46,11 @@ export default function LoginPage() {
           <form onSubmit={handleLogin} className="grid gap-4">
             <div className="grid gap-2">
               <Label htmlFor="username">아이디</Label>
-              <Input id="username" type="text" placeholder="admin" required />
+              <Input id="username" name="username" type="text" placeholder="admin" required />
             </div>
             <div className="grid gap-2">
               <Label htmlFor="password">비밀번호</Label>
-              <Input id="password" type="password" required />
+              <Input id="password" name="password" type="password" required />
             </div>
             <Button type="submit" className="w-full mt-2">
               로그인


### PR DESCRIPTION
## Summary
- add admin login endpoint
- update login form to call API and store login state
- redirect to login if not authenticated
- provide example admin credentials in `.env.example`

## Testing
- `python -m py_compile api.py db.py bot.py honey_counter.py`
- `npm run lint` *(fails: Next.js ESLint not configured)*

------
https://chatgpt.com/codex/tasks/task_e_686116b2f348832ba0df60c39387922c