### PR TITLE
Add member event tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,13 @@ docker compose up
 `NEXT_PUBLIC_API_BASE_URL` 값도 동일하게 유지해야 합니다.
 
 컨테이너는 `users.db` 파일을 호스트와 공유하므로 데이터를 유지한 채 재시작할 수 있습니다.
+
+## 데이터베이스 마이그레이션
+
+업데이트로 `member_events` 테이블이 추가되었습니다. 기존 배포에서 테이블을 생성하려면 다음 명령을 실행합니다.
+
+```bash
+sqlite3 users.db < migrations/001_create_member_events.sql
+```
+
+봇이나 API를 재시작하면 새 테이블이 자동으로 사용됩니다.

--- a/api.py
+++ b/api.py
@@ -19,15 +19,6 @@ ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "password")
 
 db.init_db()
 
-user_growth_data = [
-    {"month": "1월", "joined": 186, "left": 80},
-    {"month": "2월", "joined": 305, "left": 200},
-    {"month": "3월", "joined": 237, "left": 120},
-    {"month": "4월", "joined": 273, "left": 190},
-    {"month": "5월", "joined": 209, "left": 130},
-    {"month": "6월", "joined": 214, "left": 140},
-]
-
 
 @app.get("/users")
 def list_users():
@@ -67,7 +58,7 @@ def stats_overview():
 
 @app.get("/stats/user-growth")
 def user_growth():
-    return user_growth_data
+    return db.get_user_growth()
 
 
 @app.get("/logs/bot")

--- a/bot.py
+++ b/bot.py
@@ -384,11 +384,13 @@ async def on_member_join(member: discord.Member):
     joined_ts = int(member.joined_at.timestamp()) if member.joined_at else int(time.time())
     db.update_joined_at(str(member.id), joined_ts)
     db.set_member_status(str(member.id), True)
+    db.add_member_event(str(member.id), "joined")
 
 
 @bot.event
 async def on_member_remove(member: discord.Member):
     db.set_member_status(str(member.id), False)
+    db.add_member_event(str(member.id), "left")
 
 
 @bot.event

--- a/migrations/001_create_member_events.sql
+++ b/migrations/001_create_member_events.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS member_events (
+    user_id TEXT NOT NULL,
+    event TEXT NOT NULL,
+    timestamp INTEGER NOT NULL
+);


### PR DESCRIPTION
## Summary
- create `member_events` table for join/leave logs
- log join and leave events in `bot.py`
- compute user growth stats from DB
- expose stats via `/stats/user-growth`
- document migration step and provide SQL script

## Testing
- `python -m py_compile api.py bot.py db.py`

------
https://chatgpt.com/codex/tasks/task_e_686256eccbe0832baa16f912a89d9246