### PR TITLE
Add Discord role-based login

### DIFF
--- a/api.py
+++ b/api.py
@@ -2,8 +2,12 @@ import db
 import time
 import datetime
 import os
-from fastapi import FastAPI, HTTPException
+from urllib.parse import urlencode
+
+import httpx
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse, RedirectResponse
 
 app = FastAPI()
 app.add_middleware(
@@ -16,6 +20,26 @@ app.add_middleware(
 # Simple admin credentials for login
 ADMIN_USERNAME = os.getenv("ADMIN_USERNAME", "admin")
 ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "password")
+
+# Discord OAuth2 credentials and access rules
+DISCORD_CLIENT_ID = os.getenv("DISCORD_CLIENT_ID")
+DISCORD_CLIENT_SECRET = os.getenv("DISCORD_CLIENT_SECRET")
+DISCORD_REDIRECT_URI = os.getenv("DISCORD_REDIRECT_URI")
+
+GUILD_ID = "1346875447153000529"
+ALLOWED_ROLE_IDS = {
+    "1347330172067643522",
+    "1347330654697689248",
+    "1348535790518538250",
+    "1347332069348475004",
+    "1384521956124262480",
+    "1347122745900662835",
+    "1347110952260075581",
+    "1347122701805948928",
+    "1347111842723397673",
+    "1347122121469591653",
+    "1347122549456240722",
+}
 
 db.init_db()
 
@@ -84,3 +108,55 @@ def login(payload: dict):
     if username == ADMIN_USERNAME and password == ADMIN_PASSWORD:
         return {"status": "ok"}
     raise HTTPException(status_code=401, detail="Invalid credentials")
+
+
+@app.get("/discord/login")
+def discord_login():
+    params = {
+        "client_id": DISCORD_CLIENT_ID,
+        "redirect_uri": DISCORD_REDIRECT_URI,
+        "response_type": "code",
+        "scope": "identify guilds.members.read",
+    }
+    return RedirectResponse(
+        "https://discord.com/api/oauth2/authorize?" + urlencode(params)
+    )
+
+
+@app.get("/discord/callback")
+async def discord_callback(code: str):
+    data = {
+        "client_id": DISCORD_CLIENT_ID,
+        "client_secret": DISCORD_CLIENT_SECRET,
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": DISCORD_REDIRECT_URI,
+    }
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    async with httpx.AsyncClient() as client:
+        token_res = await client.post(
+            "https://discord.com/api/oauth2/token", data=data, headers=headers
+        )
+        if token_res.status_code != 200:
+            return HTMLResponse(
+                "<script>alert('인증 실패');window.location='/login';</script>"
+            )
+        token = token_res.json()
+        access = token.get("access_token")
+        headers = {"Authorization": f"Bearer {access}"}
+        member_res = await client.get(
+            f"https://discord.com/api/users/@me/guilds/{GUILD_ID}/member",
+            headers=headers,
+        )
+        if member_res.status_code != 200:
+            return HTMLResponse(
+                "<script>alert('서버에 가입되어 있지 않습니다.');window.location='/login';</script>"
+            )
+        roles = member_res.json().get("roles", [])
+        if not any(role in ALLOWED_ROLE_IDS for role in roles):
+            return HTMLResponse(
+                "<script>alert('권한이 없습니다.');window.location='/login';</script>"
+            )
+    return HTMLResponse(
+        "<script>localStorage.setItem('loggedIn','true');window.location='/'</script>"
+    )

--- a/flang-bot-web/app/(dashboard)/login/page.tsx
+++ b/flang-bot-web/app/(dashboard)/login/page.tsx
@@ -55,6 +55,17 @@ export default function LoginPage() {
             <Button type="submit" className="w-full mt-2">
               로그인
             </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              className="w-full"
+              onClick={() =>
+                (window.location.href =
+                  `${process.env.NEXT_PUBLIC_API_BASE_URL}/discord/login`)
+              }
+            >
+              디스코드로 로그인
+            </Button>
           </form>
         </CardContent>
       </Card>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ discord.py==2.3.2
 python-dotenv>=1.0.0
 fastapi
 uvicorn[standard]
+httpx


### PR DESCRIPTION
## Summary
- enable OAuth2 login with Discord in API
- allow login only for users from server `1346875447153000529` with specific roles
- add `httpx` to backend requirements
- add 'Login with Discord' button on the login page

## Testing
- `python -m py_compile api.py`
- `pnpm install`
- `pnpm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_686284a082f0832bbb63564b32dc4641