### PR TITLE
Add WEB_BASE_URL variable for API redirects

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,6 @@ DISCORD_CLIENT_ID=your_client_id_here
 DISCORD_CLIENT_SECRET=your_client_secret_here
 DISCORD_REDIRECT_URI=http://localhost:8000/discord/callback
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+WEB_BASE_URL=http://localhost:3000
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=changeme

--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@
    DISCORD_CLIENT_ID=애플리케이션의클라이언트ID
    DISCORD_CLIENT_SECRET=애플리케이션의클라이언트시크릿
    DISCORD_REDIRECT_URI=http://localhost:8000/discord/callback
+   WEB_BASE_URL=http://localhost:3000
    ```
    `DISCORD_CLIENT_ID`와 `DISCORD_CLIENT_SECRET`은 Discord 개발자 포털에서 확인할 수 있으며,
    `DISCORD_REDIRECT_URI` 값도 같은 포털의 OAuth2 설정에서 허용된 Redirect URI로 등록해야 합니다.
+   `WEB_BASE_URL`은 로그인 후 이동할 웹 대시보드의 주소를 의미합니다.
    혹은 `DISCORD_TOKEN` 환경 변수를 직접 설정해도 됩니다.
 
 3. `bot.py`를 실행하여 봇을 시작합니다:
@@ -59,6 +61,7 @@ DISCORD_CLIENT_ID=애플리케이션의클라이언트ID
 DISCORD_CLIENT_SECRET=애플리케이션의클라이언트시크릿
 DISCORD_REDIRECT_URI=http://localhost:8000/discord/callback
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+WEB_BASE_URL=http://localhost:3000
 ```
 
 이 값들은 빌드 단계에서도 자동으로 주입되므로, 변경 후에는 다시 이미지를 빌드해야 합니다.

--- a/api.py
+++ b/api.py
@@ -25,6 +25,7 @@ ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "password")
 DISCORD_CLIENT_ID = os.getenv("DISCORD_CLIENT_ID")
 DISCORD_CLIENT_SECRET = os.getenv("DISCORD_CLIENT_SECRET")
 DISCORD_REDIRECT_URI = os.getenv("DISCORD_REDIRECT_URI")
+WEB_BASE_URL = os.getenv("WEB_BASE_URL", "http://localhost:3000")
 
 GUILD_ID = "1346875447153000529"
 ALLOWED_ROLE_IDS = {
@@ -139,7 +140,7 @@ async def discord_callback(code: str):
         )
         if token_res.status_code != 200:
             return HTMLResponse(
-                "<script>alert('인증 실패');window.location='/login';</script>"
+                f"<script>alert('인증 실패');window.location='{WEB_BASE_URL}/login';</script>"
             )
         token = token_res.json()
         access = token.get("access_token")
@@ -150,13 +151,13 @@ async def discord_callback(code: str):
         )
         if member_res.status_code != 200:
             return HTMLResponse(
-                "<script>alert('서버에 가입되어 있지 않습니다.');window.location='/login';</script>"
+                f"<script>alert('서버에 가입되어 있지 않습니다.');window.location='{WEB_BASE_URL}/login';</script>"
             )
         roles = member_res.json().get("roles", [])
         if not any(role in ALLOWED_ROLE_IDS for role in roles):
             return HTMLResponse(
-                "<script>alert('권한이 없습니다.');window.location='/login';</script>"
+                f"<script>alert('권한이 없습니다.');window.location='{WEB_BASE_URL}/login';</script>"
             )
     return HTMLResponse(
-        "<script>localStorage.setItem('loggedIn','true');window.location='/'</script>"
+        f"<script>localStorage.setItem('loggedIn','true');window.location='{WEB_BASE_URL}/'</script>"
     )


### PR DESCRIPTION
## Summary
- configure API redirect base URL via new `WEB_BASE_URL` variable
- document the new variable in README and `.env.example`

## Testing
- `python -m py_compile api.py bot.py db.py honey_counter.py`


------
https://chatgpt.com/codex/tasks/task_e_6867eb1d7100832b882ef0272a506dfc