### PR TITLE
Handle OAuth redirect client-side

### DIFF
--- a/api.py
+++ b/api.py
@@ -158,6 +158,4 @@ async def discord_callback(code: str):
             return HTMLResponse(
                 f"<script>alert('권한이 없습니다.');window.location='{WEB_BASE_URL}/login';</script>"
             )
-    return HTMLResponse(
-        f"<script>localStorage.setItem('loggedIn','true');window.location='{WEB_BASE_URL}/'</script>"
-    )
+    return RedirectResponse(f"{WEB_BASE_URL}/login?oauth=success")

--- a/flang-bot-web/app/(dashboard)/login/page.tsx
+++ b/flang-bot-web/app/(dashboard)/login/page.tsx
@@ -1,36 +1,53 @@
-"use client"
+"use client";
 
-import type React from "react"
+import type React from "react";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Bot } from "lucide-react";
 
-import { useRouter } from "next/navigation"
-import { Bot } from "lucide-react"
-
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 
 export default function LoginPage() {
-  const router = useRouter()
+  const router = useRouter();
+
+  useEffect(() => {
+    if (
+      new URLSearchParams(window.location.search).get("oauth") === "success"
+    ) {
+      localStorage.setItem("loggedIn", "true");
+      router.push("/");
+    }
+  }, [router]);
 
   const handleLogin = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const form = event.currentTarget
-    const username = (form.elements.namedItem("username") as HTMLInputElement).value
-    const password = (form.elements.namedItem("password") as HTMLInputElement).value
+    event.preventDefault();
+    const form = event.currentTarget;
+    const username = (form.elements.namedItem("username") as HTMLInputElement)
+      .value;
+    const password = (form.elements.namedItem("password") as HTMLInputElement)
+      .value;
     try {
       const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/login`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ username, password }),
-      })
-      if (!res.ok) throw new Error("login failed")
-      localStorage.setItem("loggedIn", "true")
-      router.push("/")
+      });
+      if (!res.ok) throw new Error("login failed");
+      localStorage.setItem("loggedIn", "true");
+      router.push("/");
     } catch (err) {
-      alert("로그인 실패")
+      alert("로그인 실패");
     }
-  }
+  };
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-muted/40">
@@ -40,13 +57,21 @@ export default function LoginPage() {
             <Bot className="h-8 w-8" />
           </div>
           <CardTitle className="text-2xl">Flang-Bot 관리자 로그인</CardTitle>
-          <CardDescription>계속하려면 아이디와 비밀번호를 입력하세요.</CardDescription>
+          <CardDescription>
+            계속하려면 아이디와 비밀번호를 입력하세요.
+          </CardDescription>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleLogin} className="grid gap-4">
             <div className="grid gap-2">
               <Label htmlFor="username">아이디</Label>
-              <Input id="username" name="username" type="text" placeholder="admin" required />
+              <Input
+                id="username"
+                name="username"
+                type="text"
+                placeholder="admin"
+                required
+              />
             </div>
             <div className="grid gap-2">
               <Label htmlFor="password">비밀번호</Label>
@@ -60,8 +85,7 @@ export default function LoginPage() {
               variant="secondary"
               className="w-full"
               onClick={() =>
-                (window.location.href =
-                  `${process.env.NEXT_PUBLIC_API_BASE_URL}/discord/login`)
+                (window.location.href = `${process.env.NEXT_PUBLIC_API_BASE_URL}/discord/login`)
               }
             >
               디스코드로 로그인
@@ -70,5 +94,5 @@ export default function LoginPage() {
         </CardContent>
       </Card>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- use `RedirectResponse` instead of a script in `/discord/callback`
- detect `?oauth=success` on the dashboard login page and persist login state

## Testing
- `pytest`
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6867f4c969c4832bb1b508c40024c726