### PR TITLE
Fix mobile sidebar width and remove scroll

### DIFF
--- a/flang-bot-web/app/(dashboard)/layout.tsx
+++ b/flang-bot-web/app/(dashboard)/layout.tsx
@@ -97,7 +97,7 @@ export default function DashboardLayout({
                   <span className="sr-only">네비게이션 메뉴 열기</span>
                 </Button>
               </SheetTrigger>
-              <SheetContent side="left" className="flex flex-col">
+              <SheetContent side="left" className="flex flex-col w-72">
                 <nav className="grid gap-2 text-lg font-medium">
                   <Link href="#" className="flex items-center gap-2 text-lg font-semibold mb-4">
                     <Bot className="h-6 w-6" />

--- a/flang-bot-web/app/globals.css
+++ b/flang-bot-web/app/globals.css
@@ -4,6 +4,7 @@
 
 body {
   font-family: Arial, Helvetica, sans-serif;
+  overflow-x: hidden;
 }
 
 @layer utilities {


### PR DESCRIPTION
## Summary
- keep mobile sidebar consistent by adding `w-72`
- stop unwanted horizontal scroll with `overflow-x: hidden`

## Testing
- `pnpm lint` *(fails: ESLint config prompts)*
- `pnpm build` *(fails: unable to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_686804d789c4832bb02269b3374c61c1